### PR TITLE
[NodeJS] Add --access=public to circle config

### DIFF
--- a/synthtool/gcp/templates/node_library/.circleci/config.yml.j2
+++ b/synthtool/gcp/templates/node_library/.circleci/config.yml.j2
@@ -180,4 +180,4 @@ jobs:
     steps:
       - checkout
       - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
-      - run: npm publish
+      - run: npm publish --access=public


### PR DESCRIPTION
otherwise initial `npm publish` doesn't work because npm defaults scoped packages published to be private.