### PR TITLE
Support optional merge function during copy

### DIFF
--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -66,9 +66,7 @@ def _filter_files(paths: Iterable[Path]) -> Iterable[Path]:
 
 
 def _merge_file(
-    source_path: Path,
-    dest_path: Path,
-    merge: Callable[[str, str, Path], str]
+    source_path: Path, dest_path: Path, merge: Callable[[str, str, Path], str]
 ):
     """
     Writes to the destination the result of merging the source with the

--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -68,11 +68,14 @@ def _filter_files(paths: Iterable[Path]) -> Iterable[Path]:
 def _merge_file(
     source_path: Path,
     dest_path: Path,
-    merge: Callable[[str, str], str]
+    merge: Callable[[str, str, Path], str]
 ):
     """
     Writes to the destination the result of merging the source with the
     existing destination contents, using the given merge function.
+
+    The merge function must take three arguments: the source contents, the
+    old destination contents, and a Path to the file to be written.
     """
 
     with source_path.open("r") as source_file:
@@ -81,7 +84,7 @@ def _merge_file(
     with dest_path.open("r+") as dest_file:
         dest_text = dest_file.read()
 
-        final_text = merge(source_text, dest_text)
+        final_text = merge(source_text, dest_text, dest_path)
 
         if final_text != dest_text:
             dest_file.seek(0)

--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -94,7 +94,7 @@ def _copy_dir_to_existing_dir(
     source: Path,
     destination: Path,
     excludes: ListOfPathsOrStrs = None,
-    merge: Callable[[str, str], str] = None,
+    merge: Callable[[str, str, Path], str] = None,
 ) -> bool:
     """
     copies files over existing files to an existing directory
@@ -109,23 +109,23 @@ def _copy_dir_to_existing_dir(
     for root, _, files in os.walk(source):
         for name in files:
             rel_path = str(Path(root).relative_to(source))
-            dest_dir = os.path.join(str(destination), rel_path)
-            dest_path = os.path.join(dest_dir, name)
+            dest_dir = destination / rel_path
+            dest_path = dest_dir / name
             exclude = [
                 e
                 for e in excludes
                 if (
-                    Path(e).relative_to(".") == Path(dest_path)
-                    or Path(e).relative_to(".") == Path(dest_dir)
+                    Path(e).relative_to(".") == dest_path
+                    or Path(e).relative_to(".") == dest_dir
                 )
             ]
             if not exclude:
-                os.makedirs(dest_dir, exist_ok=True)
-                source_path = os.path.join(root, name)
+                os.makedirs(str(dest_dir), exist_ok=True)
+                source_path = Path(os.path.join(root, name))
                 if merge is not None and dest_path.is_file():
-                    _merge_file(source_path, dest_path)
+                    _merge_file(source_path, dest_path, merge)
                 else:
-                    shutil.copyfile(source_path, dest_path)
+                    shutil.copyfile(str(source_path), str(dest_path))
                 copied = True
 
     return copied
@@ -135,7 +135,7 @@ def move(
     sources: ListOfPathsOrStrs,
     destination: PathOrStr = None,
     excludes: ListOfPathsOrStrs = None,
-    merge: Callable[[str, str], str] = None,
+    merge: Callable[[str, str, Path], str] = None,
 ) -> bool:
     """
     copy file(s) at source to current directory.


### PR DESCRIPTION
Feature request for synthtool. During file copy, allows the result to be a "merge" of the contents of the source and the existing destination file. The merge function itself is provided as an optional argument to `transforms.move`.

One use case supported by this feature the ruby gemspec. This file specifies, among other things, the gem version, and the library dependencies. The former is updated during the release process (i.e. GAPIC does not know what version the gem currently is, so it cannot generate that part of the file correctly). The latter should be controlled by GAPIC (e.g. only GAPIC knows what version of google-gax its generated code depends on). Thus, the final gemspec output by synth must include the current version from the existing gemspec, and the dependency information from the freshly gapic-generated gemspec.

Open question: currently the merge function takes two arguments: the contents of the source (i.e. from-gapic) file, and the contents of the existing destination file. This is sufficient for my current use case, in which I am issuing a transforms.copy for a single file. However, maybe the merge function should also be passed the file path, so it has more information if it is invoked during a directory copy that includes multiple files? (And if so, should it be passed the source file path or the destination file path, or both?)