### PR TITLE
Add git sources to tracked_paths

### DIFF
--- a/synthtool/sources/git.py
+++ b/synthtool/sources/git.py
@@ -15,6 +15,7 @@
 import pathlib
 import shutil
 
+from synthtool import _tracked_paths
 from synthtool import cache
 from synthtool import shell
 
@@ -43,5 +44,8 @@ def clone(
         shell.run(["git", "pull"], cwd=str(dest))
 
     shell.run(["git", "reset", "--hard", committish], cwd=str(dest))
+
+    # track all git repositories
+    _tracked_paths.add(dest)
 
     return dest


### PR DESCRIPTION
Automatically track all cloned git repo paths. Many code generators operate within their own repository and do not provide an option for where the generated code is placed. For these synth scripts, the user can use the `git` and `shell` tools to run the codegen process. The output files need to be in a tracked path or they cannot be found and the user should not be setting `_tracked_paths` themselves.

This PR makes #27 unnecessary.