### PR TITLE
Run `npm install` before publishing

### DIFF
--- a/synthtool/gcp/templates/node_library/.circleci/config.yml.j2
+++ b/synthtool/gcp/templates/node_library/.circleci/config.yml.j2
@@ -107,9 +107,7 @@ jobs:
     steps:
       - checkout
       - run: *npm_install_and_link
-      - run:
-          name: Build documentation.
-          command: npm run docs
+      - run: npm run docs
   sample_tests:
     docker:
       - image: 'node:8'
@@ -164,5 +162,6 @@ jobs:
         user: node
     steps:
       - checkout
-      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
+      - npm install
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run: npm publish --access=public


### PR DESCRIPTION
This fixes a bug with publishing TypeScript packages. 