### PR TITLE
Move: excludes arg paths should be relative to source, not destination

### DIFF
--- a/synthtool/transforms.py
+++ b/synthtool/transforms.py
@@ -115,8 +115,8 @@ def _copy_dir_to_existing_dir(
                 e
                 for e in excludes
                 if (
-                    Path(e).relative_to(".") == dest_path
-                    or Path(e).relative_to(".") == dest_dir
+                    Path(e).relative_to(".") == Path(rel_path)
+                    or Path(e).relative_to(".") == Path(rel_path) / name
                 )
             ]
             if not exclude:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -92,14 +92,9 @@ def test__move_to_dest(expand_path_fixtures):
     _tracked_paths.add(expand_path_fixtures)
     dest = Path(str(expand_path_fixtures / "dest"))
 
-    transforms.move(
-        tmp_path,
-        dest,
-        excludes=["dira/f.py"])
+    transforms.move(tmp_path, dest, excludes=["dira/f.py"])
 
-    files = sorted(
-        [str(x) for x in transforms._expand_paths("**/*", root='dest')]
-    )
+    files = sorted([str(x) for x in transforms._expand_paths("**/*", root="dest")])
 
     # Assert destination does not contain dira/e.py (excluded)
     assert files == [

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import os
+from pathlib import Path
 
 import pytest
 
 from synthtool import transforms
+from synthtool import _tracked_paths
 
 
 @pytest.fixture()
@@ -82,4 +84,31 @@ def test__filter_files(expand_path_fixtures):
         "dira/e.txt",
         "dira/f.py",
         "dirb/suba/g.py",
+    ]
+
+
+def test__move_to_dest(expand_path_fixtures):
+    tmp_path = Path(str(expand_path_fixtures))
+    _tracked_paths.add(expand_path_fixtures)
+    dest = Path(str(expand_path_fixtures / "dest"))
+
+    transforms.move(
+        tmp_path,
+        dest,
+        excludes=["dira/f.py"])
+
+    files = sorted(
+        [str(x) for x in transforms._expand_paths("**/*", root='dest')]
+    )
+
+    # Assert destination does not contain dira/e.py (excluded)
+    assert files == [
+        "dest/a.txt",
+        "dest/b.py",
+        "dest/c.md",
+        "dest/dira",
+        "dest/dira/e.txt",
+        "dest/dirb",
+        "dest/dirb/suba",
+        "dest/dirb/suba/g.py",
     ]


### PR DESCRIPTION
```python
transforms.move(
    source,
    destination,
    excludes=['garbage.md']) # after this change, this will be relative to the source, not destination
```

So if there exists a `source/garbage.md`, it will be ignored.

Please let me know if this change makes sense to you.