### PR TITLE
add GCLOUD_PROJECT env var to config.yml

### DIFF
--- a/synthtool/gcp/templates/node_library/.circleci/config.yml
+++ b/synthtool/gcp/templates/node_library/.circleci/config.yml
@@ -160,6 +160,7 @@ jobs:
           name: Run system tests.
           command: npm run system-test
           environment:
+            GCLOUD_PROJECT: long-door-651
             GOOGLE_APPLICATION_CREDENTIALS: .circleci/key.json
       - run:
           name: Remove unencrypted key.


### PR DESCRIPTION
 This will fix nodejs-dlp's system-test failures on master: https://circleci.com/workflow-run/9f90675e-df3b-452f-a2e9-bc1ef6f1d9bb