### PR TITLE
node: add a pretest hook on system test

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
@@ -21,6 +21,11 @@ export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
 
 cd $(dirname $0)/..
 
+# Run a pre-test hook, if a pre-system-test.sh is in the project
+if [ -f .kokoro/pre-system-test.sh ]; then
+    . .kokoro/pre-system-test.sh
+fi
+
 npm install
 
 npm run system-test


### PR DESCRIPTION
This allow some (non-autogenerated) repositories to have custom logic before certain tests are run.

In this case I've implemented it for system-test, but we will likely have one for each test (test.sh, samples-test.sh) depending on need.

Specifically, we need this in nodejs-storage to export 2 additional environment variables (the second project/service account).