### PR TITLE
nodejs: export GCLOUD_PROJECT in system-test

### DIFF
--- a/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
+++ b/synthtool/gcp/templates/node_library/.kokoro/system-test.sh
@@ -20,6 +20,7 @@ export NPM_CONFIG_PREFIX=/home/node/.npm-global
 
 # Setup service account credentials.
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/service-account.json
+export GCLOUD_PROJECT=long-door-651
 
 cd $(dirname $0)/..
 


### PR DESCRIPTION
This is currently causing nodejs-dlp's system-test to [fail](https://source.cloud.google.com/results/invocations/05366cda-3997-406f-a744-a6aea902682e/targets/cloud-devrel%2Fclient-libraries%2Fnodejs%2Fgoogleapis%2Fnodejs-dlp%2Fcontinuous%2Fnode8%2Fsystem-test/log).